### PR TITLE
Backend integration, data and graph

### DIFF
--- a/frontend-svelte/package-lock.json
+++ b/frontend-svelte/package-lock.json
@@ -8,6 +8,7 @@
       "name": "test",
       "version": "0.0.0",
       "dependencies": {
+        "firebase": "^10.5.2",
         "plotly.js": "^2.27.0",
         "plotly.js-dist": "^2.27.0"
       },
@@ -393,6 +394,529 @@
         "node": ">=12"
       }
     },
+    "node_modules/@firebase/analytics": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@firebase/analytics/-/analytics-0.10.0.tgz",
+      "integrity": "sha512-Locv8gAqx0e+GX/0SI3dzmBY5e9kjVDtD+3zCFLJ0tH2hJwuCAiL+5WkHuxKj92rqQj/rvkBUCfA1ewlX2hehg==",
+      "dependencies": {
+        "@firebase/component": "0.6.4",
+        "@firebase/installations": "0.6.4",
+        "@firebase/logger": "0.4.0",
+        "@firebase/util": "1.9.3",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/analytics-compat": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/@firebase/analytics-compat/-/analytics-compat-0.2.6.tgz",
+      "integrity": "sha512-4MqpVLFkGK7NJf/5wPEEP7ePBJatwYpyjgJ+wQHQGHfzaCDgntOnl9rL2vbVGGKCnRqWtZDIWhctB86UWXaX2Q==",
+      "dependencies": {
+        "@firebase/analytics": "0.10.0",
+        "@firebase/analytics-types": "0.8.0",
+        "@firebase/component": "0.6.4",
+        "@firebase/util": "1.9.3",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/analytics-types": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@firebase/analytics-types/-/analytics-types-0.8.0.tgz",
+      "integrity": "sha512-iRP+QKI2+oz3UAh4nPEq14CsEjrjD6a5+fuypjScisAh9kXKFvdJOZJDwk7kikLvWVLGEs9+kIUS4LPQV7VZVw=="
+    },
+    "node_modules/@firebase/app": {
+      "version": "0.9.22",
+      "resolved": "https://registry.npmjs.org/@firebase/app/-/app-0.9.22.tgz",
+      "integrity": "sha512-4hbUg9ojPbn4Gj21Z/GnJbiLQYOzkwBDFT5vBkQgUJJGS28qQLG6eZZ1DwLKh8lcrNJc4MR90OPaJWhSzJCR2w==",
+      "dependencies": {
+        "@firebase/component": "0.6.4",
+        "@firebase/logger": "0.4.0",
+        "@firebase/util": "1.9.3",
+        "idb": "7.1.1",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@firebase/app-check": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@firebase/app-check/-/app-check-0.8.0.tgz",
+      "integrity": "sha512-dRDnhkcaC2FspMiRK/Vbp+PfsOAEP6ZElGm9iGFJ9fDqHoPs0HOPn7dwpJ51lCFi1+2/7n5pRPGhqF/F03I97g==",
+      "dependencies": {
+        "@firebase/component": "0.6.4",
+        "@firebase/logger": "0.4.0",
+        "@firebase/util": "1.9.3",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/app-check-compat": {
+      "version": "0.3.7",
+      "resolved": "https://registry.npmjs.org/@firebase/app-check-compat/-/app-check-compat-0.3.7.tgz",
+      "integrity": "sha512-cW682AxsyP1G+Z0/P7pO/WT2CzYlNxoNe5QejVarW2o5ZxeWSSPAiVEwpEpQR/bUlUmdeWThYTMvBWaopdBsqw==",
+      "dependencies": {
+        "@firebase/app-check": "0.8.0",
+        "@firebase/app-check-types": "0.5.0",
+        "@firebase/component": "0.6.4",
+        "@firebase/logger": "0.4.0",
+        "@firebase/util": "1.9.3",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/app-check-interop-types": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@firebase/app-check-interop-types/-/app-check-interop-types-0.3.0.tgz",
+      "integrity": "sha512-xAxHPZPIgFXnI+vb4sbBjZcde7ZluzPPaSK7Lx3/nmuVk4TjZvnL8ONnkd4ERQKL8WePQySU+pRcWkh8rDf5Sg=="
+    },
+    "node_modules/@firebase/app-check-types": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@firebase/app-check-types/-/app-check-types-0.5.0.tgz",
+      "integrity": "sha512-uwSUj32Mlubybw7tedRzR24RP8M8JUVR3NPiMk3/Z4bCmgEKTlQBwMXrehDAZ2wF+TsBq0SN1c6ema71U/JPyQ=="
+    },
+    "node_modules/@firebase/app-compat": {
+      "version": "0.2.22",
+      "resolved": "https://registry.npmjs.org/@firebase/app-compat/-/app-compat-0.2.22.tgz",
+      "integrity": "sha512-kyksJFA19Oz5HZmR56s/ziOM6ivDBF9JYwC0ufacooYNd2sQ3pRsi5MZAYb1FR9hCE7MgoHuPmTtBHA7S/Cv8g==",
+      "dependencies": {
+        "@firebase/app": "0.9.22",
+        "@firebase/component": "0.6.4",
+        "@firebase/logger": "0.4.0",
+        "@firebase/util": "1.9.3",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@firebase/app-types": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@firebase/app-types/-/app-types-0.9.0.tgz",
+      "integrity": "sha512-AeweANOIo0Mb8GiYm3xhTEBVCmPwTYAu9Hcd2qSkLuga/6+j9b1Jskl5bpiSQWy9eJ/j5pavxj6eYogmnuzm+Q=="
+    },
+    "node_modules/@firebase/auth": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@firebase/auth/-/auth-1.3.2.tgz",
+      "integrity": "sha512-ksYpeRACL8INRpFZzbCLLnI9NP+L3UH/+ebKo4oBjhc/dSwPbpw6E1wjdm0odB1U5xHhXD/5lpyeFQZ+jXyBxA==",
+      "dependencies": {
+        "@firebase/component": "0.6.4",
+        "@firebase/logger": "0.4.0",
+        "@firebase/util": "1.9.3",
+        "node-fetch": "2.6.7",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x",
+        "@react-native-async-storage/async-storage": "^1.18.1"
+      },
+      "peerDependenciesMeta": {
+        "@react-native-async-storage/async-storage": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@firebase/auth-compat": {
+      "version": "0.4.8",
+      "resolved": "https://registry.npmjs.org/@firebase/auth-compat/-/auth-compat-0.4.8.tgz",
+      "integrity": "sha512-qKX8BOl1qewBzpfAXl6/lKPW7fjnY8/3umiSFIGO8SHwLQ3LsAdNFPdwafouwMiKLo5MXxW4XdxNSI4ilt0Z5w==",
+      "dependencies": {
+        "@firebase/auth": "1.3.2",
+        "@firebase/auth-types": "0.12.0",
+        "@firebase/component": "0.6.4",
+        "@firebase/util": "1.9.3",
+        "node-fetch": "2.6.7",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/auth-interop-types": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@firebase/auth-interop-types/-/auth-interop-types-0.2.1.tgz",
+      "integrity": "sha512-VOaGzKp65MY6P5FI84TfYKBXEPi6LmOCSMMzys6o2BN2LOsqy7pCuZCup7NYnfbk5OkkQKzvIfHOzTm0UDpkyg=="
+    },
+    "node_modules/@firebase/auth-types": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@firebase/auth-types/-/auth-types-0.12.0.tgz",
+      "integrity": "sha512-pPwaZt+SPOshK8xNoiQlK5XIrS97kFYc3Rc7xmy373QsOJ9MmqXxLaYssP5Kcds4wd2qK//amx/c+A8O2fVeZA==",
+      "peerDependencies": {
+        "@firebase/app-types": "0.x",
+        "@firebase/util": "1.x"
+      }
+    },
+    "node_modules/@firebase/component": {
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/@firebase/component/-/component-0.6.4.tgz",
+      "integrity": "sha512-rLMyrXuO9jcAUCaQXCMjCMUsWrba5fzHlNK24xz5j2W6A/SRmK8mZJ/hn7V0fViLbxC0lPMtrK1eYzk6Fg03jA==",
+      "dependencies": {
+        "@firebase/util": "1.9.3",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@firebase/database": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@firebase/database/-/database-1.0.1.tgz",
+      "integrity": "sha512-VAhF7gYwunW4Lw/+RQZvW8dlsf2r0YYqV9W0Gi2Mz8+0TGg1mBJWoUtsHfOr8kPJXhcLsC4eP/z3x6L/Fvjk/A==",
+      "dependencies": {
+        "@firebase/auth-interop-types": "0.2.1",
+        "@firebase/component": "0.6.4",
+        "@firebase/logger": "0.4.0",
+        "@firebase/util": "1.9.3",
+        "faye-websocket": "0.11.4",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@firebase/database-compat": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@firebase/database-compat/-/database-compat-1.0.1.tgz",
+      "integrity": "sha512-ky82yLIboLxtAIWyW/52a6HLMVTzD2kpZlEilVDok73pNPLjkJYowj8iaIWK5nTy7+6Gxt7d00zfjL6zckGdXQ==",
+      "dependencies": {
+        "@firebase/component": "0.6.4",
+        "@firebase/database": "1.0.1",
+        "@firebase/database-types": "1.0.0",
+        "@firebase/logger": "0.4.0",
+        "@firebase/util": "1.9.3",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@firebase/database-types": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@firebase/database-types/-/database-types-1.0.0.tgz",
+      "integrity": "sha512-SjnXStoE0Q56HcFgNQ+9SsmJc0c8TqGARdI/T44KXy+Ets3r6x/ivhQozT66bMnCEjJRywYoxNurRTMlZF8VNg==",
+      "dependencies": {
+        "@firebase/app-types": "0.9.0",
+        "@firebase/util": "1.9.3"
+      }
+    },
+    "node_modules/@firebase/firestore": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@firebase/firestore/-/firestore-4.3.2.tgz",
+      "integrity": "sha512-K4TwMbgArWw+XAEUYX/vtk+TVy9n1uLeJKSrQeb89lwfkfyFINGLPME6YleaS0ovD1ziLM5/0WgL1CR4s53fDg==",
+      "dependencies": {
+        "@firebase/component": "0.6.4",
+        "@firebase/logger": "0.4.0",
+        "@firebase/util": "1.9.3",
+        "@firebase/webchannel-wrapper": "0.10.3",
+        "@grpc/grpc-js": "~1.9.0",
+        "@grpc/proto-loader": "^0.7.8",
+        "node-fetch": "2.6.7",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=10.10.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/firestore-compat": {
+      "version": "0.3.21",
+      "resolved": "https://registry.npmjs.org/@firebase/firestore-compat/-/firestore-compat-0.3.21.tgz",
+      "integrity": "sha512-u17so8cP4FQBEJyivAbZc0kW09YBXBvhSmUXiB7swkOLemfZUmmPZQGJxZGa9y/M02euU1y4EzvWN/h/bkx8pg==",
+      "dependencies": {
+        "@firebase/component": "0.6.4",
+        "@firebase/firestore": "4.3.2",
+        "@firebase/firestore-types": "3.0.0",
+        "@firebase/util": "1.9.3",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/firestore-types": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@firebase/firestore-types/-/firestore-types-3.0.0.tgz",
+      "integrity": "sha512-Meg4cIezHo9zLamw0ymFYBD4SMjLb+ZXIbuN7T7ddXN6MGoICmOTq3/ltdCGoDCS2u+H1XJs2u/cYp75jsX9Qw==",
+      "peerDependencies": {
+        "@firebase/app-types": "0.x",
+        "@firebase/util": "1.x"
+      }
+    },
+    "node_modules/@firebase/functions": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@firebase/functions/-/functions-0.10.0.tgz",
+      "integrity": "sha512-2U+fMNxTYhtwSpkkR6WbBcuNMOVaI7MaH3cZ6UAeNfj7AgEwHwMIFLPpC13YNZhno219F0lfxzTAA0N62ndWzA==",
+      "dependencies": {
+        "@firebase/app-check-interop-types": "0.3.0",
+        "@firebase/auth-interop-types": "0.2.1",
+        "@firebase/component": "0.6.4",
+        "@firebase/messaging-interop-types": "0.2.0",
+        "@firebase/util": "1.9.3",
+        "node-fetch": "2.6.7",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/functions-compat": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/@firebase/functions-compat/-/functions-compat-0.3.5.tgz",
+      "integrity": "sha512-uD4jwgwVqdWf6uc3NRKF8cSZ0JwGqSlyhPgackyUPe+GAtnERpS4+Vr66g0b3Gge0ezG4iyHo/EXW/Hjx7QhHw==",
+      "dependencies": {
+        "@firebase/component": "0.6.4",
+        "@firebase/functions": "0.10.0",
+        "@firebase/functions-types": "0.6.0",
+        "@firebase/util": "1.9.3",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/functions-types": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@firebase/functions-types/-/functions-types-0.6.0.tgz",
+      "integrity": "sha512-hfEw5VJtgWXIRf92ImLkgENqpL6IWpYaXVYiRkFY1jJ9+6tIhWM7IzzwbevwIIud/jaxKVdRzD7QBWfPmkwCYw=="
+    },
+    "node_modules/@firebase/installations": {
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/@firebase/installations/-/installations-0.6.4.tgz",
+      "integrity": "sha512-u5y88rtsp7NYkCHC3ElbFBrPtieUybZluXyzl7+4BsIz4sqb4vSAuwHEUgCgCeaQhvsnxDEU6icly8U9zsJigA==",
+      "dependencies": {
+        "@firebase/component": "0.6.4",
+        "@firebase/util": "1.9.3",
+        "idb": "7.0.1",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/installations-compat": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/@firebase/installations-compat/-/installations-compat-0.2.4.tgz",
+      "integrity": "sha512-LI9dYjp0aT9Njkn9U4JRrDqQ6KXeAmFbRC0E7jI7+hxl5YmRWysq5qgQl22hcWpTk+cm3es66d/apoDU/A9n6Q==",
+      "dependencies": {
+        "@firebase/component": "0.6.4",
+        "@firebase/installations": "0.6.4",
+        "@firebase/installations-types": "0.5.0",
+        "@firebase/util": "1.9.3",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/installations-types": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@firebase/installations-types/-/installations-types-0.5.0.tgz",
+      "integrity": "sha512-9DP+RGfzoI2jH7gY4SlzqvZ+hr7gYzPODrbzVD82Y12kScZ6ZpRg/i3j6rleto8vTFC8n6Len4560FnV1w2IRg==",
+      "peerDependencies": {
+        "@firebase/app-types": "0.x"
+      }
+    },
+    "node_modules/@firebase/installations/node_modules/idb": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/idb/-/idb-7.0.1.tgz",
+      "integrity": "sha512-UUxlE7vGWK5RfB/fDwEGgRf84DY/ieqNha6msMV99UsEMQhJ1RwbCd8AYBj3QMgnE3VZnfQvm4oKVCJTYlqIgg=="
+    },
+    "node_modules/@firebase/logger": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@firebase/logger/-/logger-0.4.0.tgz",
+      "integrity": "sha512-eRKSeykumZ5+cJPdxxJRgAC3G5NknY2GwEbKfymdnXtnT0Ucm4pspfR6GT4MUQEDuJwRVbVcSx85kgJulMoFFA==",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@firebase/messaging": {
+      "version": "0.12.4",
+      "resolved": "https://registry.npmjs.org/@firebase/messaging/-/messaging-0.12.4.tgz",
+      "integrity": "sha512-6JLZct6zUaex4g7HI3QbzeUrg9xcnmDAPTWpkoMpd/GoSVWH98zDoWXMGrcvHeCAIsLpFMe4MPoZkJbrPhaASw==",
+      "dependencies": {
+        "@firebase/component": "0.6.4",
+        "@firebase/installations": "0.6.4",
+        "@firebase/messaging-interop-types": "0.2.0",
+        "@firebase/util": "1.9.3",
+        "idb": "7.0.1",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/messaging-compat": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/@firebase/messaging-compat/-/messaging-compat-0.2.4.tgz",
+      "integrity": "sha512-lyFjeUhIsPRYDPNIkYX1LcZMpoVbBWXX4rPl7c/rqc7G+EUea7IEtSt4MxTvh6fDfPuzLn7+FZADfscC+tNMfg==",
+      "dependencies": {
+        "@firebase/component": "0.6.4",
+        "@firebase/messaging": "0.12.4",
+        "@firebase/util": "1.9.3",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/messaging-interop-types": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@firebase/messaging-interop-types/-/messaging-interop-types-0.2.0.tgz",
+      "integrity": "sha512-ujA8dcRuVeBixGR9CtegfpU4YmZf3Lt7QYkcj693FFannwNuZgfAYaTmbJ40dtjB81SAu6tbFPL9YLNT15KmOQ=="
+    },
+    "node_modules/@firebase/messaging/node_modules/idb": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/idb/-/idb-7.0.1.tgz",
+      "integrity": "sha512-UUxlE7vGWK5RfB/fDwEGgRf84DY/ieqNha6msMV99UsEMQhJ1RwbCd8AYBj3QMgnE3VZnfQvm4oKVCJTYlqIgg=="
+    },
+    "node_modules/@firebase/performance": {
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/@firebase/performance/-/performance-0.6.4.tgz",
+      "integrity": "sha512-HfTn/bd8mfy/61vEqaBelNiNnvAbUtME2S25A67Nb34zVuCSCRIX4SseXY6zBnOFj3oLisaEqhVcJmVPAej67g==",
+      "dependencies": {
+        "@firebase/component": "0.6.4",
+        "@firebase/installations": "0.6.4",
+        "@firebase/logger": "0.4.0",
+        "@firebase/util": "1.9.3",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/performance-compat": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/@firebase/performance-compat/-/performance-compat-0.2.4.tgz",
+      "integrity": "sha512-nnHUb8uP9G8islzcld/k6Bg5RhX62VpbAb/Anj7IXs/hp32Eb2LqFPZK4sy3pKkBUO5wcrlRWQa6wKOxqlUqsg==",
+      "dependencies": {
+        "@firebase/component": "0.6.4",
+        "@firebase/logger": "0.4.0",
+        "@firebase/performance": "0.6.4",
+        "@firebase/performance-types": "0.2.0",
+        "@firebase/util": "1.9.3",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/performance-types": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@firebase/performance-types/-/performance-types-0.2.0.tgz",
+      "integrity": "sha512-kYrbr8e/CYr1KLrLYZZt2noNnf+pRwDq2KK9Au9jHrBMnb0/C9X9yWSXmZkFt4UIdsQknBq8uBB7fsybZdOBTA=="
+    },
+    "node_modules/@firebase/remote-config": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/@firebase/remote-config/-/remote-config-0.4.4.tgz",
+      "integrity": "sha512-x1ioTHGX8ZwDSTOVp8PBLv2/wfwKzb4pxi0gFezS5GCJwbLlloUH4YYZHHS83IPxnua8b6l0IXUaWd0RgbWwzQ==",
+      "dependencies": {
+        "@firebase/component": "0.6.4",
+        "@firebase/installations": "0.6.4",
+        "@firebase/logger": "0.4.0",
+        "@firebase/util": "1.9.3",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/remote-config-compat": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/@firebase/remote-config-compat/-/remote-config-compat-0.2.4.tgz",
+      "integrity": "sha512-FKiki53jZirrDFkBHglB3C07j5wBpitAaj8kLME6g8Mx+aq7u9P7qfmuSRytiOItADhWUj7O1JIv7n9q87SuwA==",
+      "dependencies": {
+        "@firebase/component": "0.6.4",
+        "@firebase/logger": "0.4.0",
+        "@firebase/remote-config": "0.4.4",
+        "@firebase/remote-config-types": "0.3.0",
+        "@firebase/util": "1.9.3",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/remote-config-types": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@firebase/remote-config-types/-/remote-config-types-0.3.0.tgz",
+      "integrity": "sha512-RtEH4vdcbXZuZWRZbIRmQVBNsE7VDQpet2qFvq6vwKLBIQRQR5Kh58M4ok3A3US8Sr3rubYnaGqZSurCwI8uMA=="
+    },
+    "node_modules/@firebase/storage": {
+      "version": "0.11.2",
+      "resolved": "https://registry.npmjs.org/@firebase/storage/-/storage-0.11.2.tgz",
+      "integrity": "sha512-CtvoFaBI4hGXlXbaCHf8humajkbXhs39Nbh6MbNxtwJiCqxPy9iH3D3CCfXAvP0QvAAwmJUTK3+z9a++Kc4nkA==",
+      "dependencies": {
+        "@firebase/component": "0.6.4",
+        "@firebase/util": "1.9.3",
+        "node-fetch": "2.6.7",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/storage-compat": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@firebase/storage-compat/-/storage-compat-0.3.2.tgz",
+      "integrity": "sha512-wvsXlLa9DVOMQJckbDNhXKKxRNNewyUhhbXev3t8kSgoCotd1v3MmqhKKz93ePhDnhHnDs7bYHy+Qa8dRY6BXw==",
+      "dependencies": {
+        "@firebase/component": "0.6.4",
+        "@firebase/storage": "0.11.2",
+        "@firebase/storage-types": "0.8.0",
+        "@firebase/util": "1.9.3",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/storage-types": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@firebase/storage-types/-/storage-types-0.8.0.tgz",
+      "integrity": "sha512-isRHcGrTs9kITJC0AVehHfpraWFui39MPaU7Eo8QfWlqW7YPymBmRgjDrlOgFdURh6Cdeg07zmkLP5tzTKRSpg==",
+      "peerDependencies": {
+        "@firebase/app-types": "0.x",
+        "@firebase/util": "1.x"
+      }
+    },
+    "node_modules/@firebase/util": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/@firebase/util/-/util-1.9.3.tgz",
+      "integrity": "sha512-DY02CRhOZwpzO36fHpuVysz6JZrscPiBXD0fXp6qSrL9oNOx5KWICKdR95C0lSITzxp0TZosVyHqzatE8JbcjA==",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@firebase/webchannel-wrapper": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@firebase/webchannel-wrapper/-/webchannel-wrapper-0.10.3.tgz",
+      "integrity": "sha512-+ZplYUN3HOpgCfgInqgdDAbkGGVzES1cs32JJpeqoh87SkRobGXElJx+1GZSaDqzFL+bYiX18qEcBK76mYs8uA=="
+    },
+    "node_modules/@grpc/grpc-js": {
+      "version": "1.9.9",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.9.9.tgz",
+      "integrity": "sha512-vQ1qwi/Kiyprt+uhb1+rHMpyk4CVRMTGNUGGPRGS7pLNfWkdCHrGEnT6T3/JyC2VZgoOX/X1KwdoU0WYQAeYcQ==",
+      "dependencies": {
+        "@grpc/proto-loader": "^0.7.8",
+        "@types/node": ">=12.12.47"
+      },
+      "engines": {
+        "node": "^8.13.0 || >=10.10.0"
+      }
+    },
+    "node_modules/@grpc/proto-loader": {
+      "version": "0.7.10",
+      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.7.10.tgz",
+      "integrity": "sha512-CAqDfoaQ8ykFd9zqBDn4k6iWT9loLAlc2ETmDFS9JCD70gDcnA4L3AFEo2iV7KyAtAAHFW9ftq1Fz+Vsgq80RQ==",
+      "dependencies": {
+        "lodash.camelcase": "^4.3.0",
+        "long": "^5.0.0",
+        "protobufjs": "^7.2.4",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "proto-loader-gen-types": "build/bin/proto-loader-gen-types.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.3.tgz",
@@ -548,6 +1072,60 @@
         "pick-by-alias": "^1.2.0"
       }
     },
+    "node_modules/@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ=="
+    },
+    "node_modules/@protobufjs/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg=="
+    },
+    "node_modules/@protobufjs/codegen": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
+      "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg=="
+    },
+    "node_modules/@protobufjs/eventemitter": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
+      "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q=="
+    },
+    "node_modules/@protobufjs/fetch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
+      "integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.1",
+        "@protobufjs/inquire": "^1.1.0"
+      }
+    },
+    "node_modules/@protobufjs/float": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ=="
+    },
+    "node_modules/@protobufjs/inquire": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
+      "integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q=="
+    },
+    "node_modules/@protobufjs/path": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA=="
+    },
+    "node_modules/@protobufjs/pool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw=="
+    },
+    "node_modules/@protobufjs/utf8": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
+      "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="
+    },
     "node_modules/@sveltejs/vite-plugin-svelte": {
       "version": "2.4.6",
       "resolved": "https://registry.npmjs.org/@sveltejs/vite-plugin-svelte/-/vite-plugin-svelte-2.4.6.tgz",
@@ -648,6 +1226,14 @@
       "integrity": "sha512-VeiPZ9MMwXjO32/Xu7+OwflfmeoRwkE/qzndw42gGtgJwZopBnzy2gD//NN1+go1mADzkDcqf/KnFRSjTJ8xJA==",
       "dev": true
     },
+    "node_modules/@types/node": {
+      "version": "20.8.9",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.8.9.tgz",
+      "integrity": "sha512-UzykFsT3FhHb1h7yD4CA4YhBHq545JC0YnEz41xkipN88eKQtL6rSgocL5tbAP6Ola9Izm/Aw4Ora8He4x0BHg==",
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
+    },
     "node_modules/abs-svg-path": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/abs-svg-path/-/abs-svg-path-0.1.1.tgz",
@@ -669,6 +1255,28 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/almost-equal/-/almost-equal-1.1.0.tgz",
       "integrity": "sha512-0V/PkoculFl5+0Lp47JoxUcO0xSxhIBvm+BxHdD/OgXNmdRpRHCFnKVuUoWyS9EzQP+otSGv0m9Lb4yVkQBn2A=="
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
     },
     "node_modules/aria-query": {
       "version": "5.3.0",
@@ -761,6 +1369,19 @@
       "resolved": "https://registry.npmjs.org/clamp/-/clamp-1.0.1.tgz",
       "integrity": "sha512-kgMuFyE78OC6Dyu3Dy7vcx4uy97EIbVxJB/B0eJ3bUNAkwdNcxYzgKltnyADiYwsR7SEqkkUPsEUT//OVS6XMA=="
     },
+    "node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/code-red": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/code-red/-/code-red-1.0.4.tgz",
@@ -780,6 +1401,17 @@
       "integrity": "sha512-lr8/t5NPozTSqli+duAN+x+no/2WaKTeWvxhHGN+aXT6AJ8vPlzLa7UriyjWak0pSC2jHol9JgjBYnnHsGha9A==",
       "dependencies": {
         "color-parse": "^1.3.8"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
       }
     },
     "node_modules/color-id": {
@@ -1157,6 +1789,11 @@
         "strongly-connected-components": "^1.0.1"
       }
     },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
+    },
     "node_modules/end-of-stream": {
       "version": "1.4.4",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
@@ -1244,6 +1881,14 @@
         "@esbuild/win32-arm64": "0.18.20",
         "@esbuild/win32-ia32": "0.18.20",
         "@esbuild/win32-x64": "0.18.20"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
+      "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/escodegen": {
@@ -1361,6 +2006,50 @@
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw=="
     },
+    "node_modules/faye-websocket": {
+      "version": "0.11.4",
+      "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.11.4.tgz",
+      "integrity": "sha512-CzbClwlXAuiRQAlUyfqPgvPoNKTckTPGfwZV4ZdAhVcP2lh9KUxJg2b5GkE7XbjKQ3YJnQ9z6D9ntLAlB+tP8g==",
+      "dependencies": {
+        "websocket-driver": ">=0.5.1"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/firebase": {
+      "version": "10.5.2",
+      "resolved": "https://registry.npmjs.org/firebase/-/firebase-10.5.2.tgz",
+      "integrity": "sha512-LLCig21TBYdByMbGJt5YmUzzk2HpsFCsIUTvOteQjW9BUh40IrSP2+dZi9IvT8RlztM3zcH+TNZ0jOsOaa7GMQ==",
+      "dependencies": {
+        "@firebase/analytics": "0.10.0",
+        "@firebase/analytics-compat": "0.2.6",
+        "@firebase/app": "0.9.22",
+        "@firebase/app-check": "0.8.0",
+        "@firebase/app-check-compat": "0.3.7",
+        "@firebase/app-compat": "0.2.22",
+        "@firebase/app-types": "0.9.0",
+        "@firebase/auth": "1.3.2",
+        "@firebase/auth-compat": "0.4.8",
+        "@firebase/database": "1.0.1",
+        "@firebase/database-compat": "1.0.1",
+        "@firebase/firestore": "4.3.2",
+        "@firebase/firestore-compat": "0.3.21",
+        "@firebase/functions": "0.10.0",
+        "@firebase/functions-compat": "0.3.5",
+        "@firebase/installations": "0.6.4",
+        "@firebase/installations-compat": "0.2.4",
+        "@firebase/messaging": "0.12.4",
+        "@firebase/messaging-compat": "0.2.4",
+        "@firebase/performance": "0.6.4",
+        "@firebase/performance-compat": "0.2.4",
+        "@firebase/remote-config": "0.4.4",
+        "@firebase/remote-config-compat": "0.2.4",
+        "@firebase/storage": "0.11.2",
+        "@firebase/storage-compat": "0.3.2",
+        "@firebase/util": "1.9.3"
+      }
+    },
     "node_modules/flatten-vertex-data": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/flatten-vertex-data/-/flatten-vertex-data-1.0.2.tgz",
@@ -1420,6 +2109,14 @@
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/geojson-vt/-/geojson-vt-3.2.1.tgz",
       "integrity": "sha512-EvGQQi/zPrDA6zr6BnJD/YhwAkBP8nnJ9emh3EnHQKVMfg/MRVtPbMYdgVy/IaEmn4UfagD2a6fafPDL5hbtwg=="
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
     },
     "node_modules/get-canvas-context": {
       "version": "1.0.2",
@@ -1708,6 +2405,11 @@
       "resolved": "https://registry.npmjs.org/hsluv/-/hsluv-0.0.3.tgz",
       "integrity": "sha512-08iL2VyCRbkQKBySkSh6m8zMUa3sADAxGVWs3Z1aPcUkTJeK0ETG4Fc27tEmQBGUAXZjIsXOZqBvacuVNSC/fQ=="
     },
+    "node_modules/http-parser-js": {
+      "version": "0.5.8",
+      "resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.5.8.tgz",
+      "integrity": "sha512-SGeBX54F94Wgu5RH3X5jsDtf4eHyRogWX1XGT3b4HuW3tQPM4AaBzoUji/4AAJNXCEOWZ5O0DgZmJw1947gD5Q=="
+    },
     "node_modules/iconv-lite": {
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
@@ -1718,6 +2420,11 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/idb": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/idb/-/idb-7.1.1.tgz",
+      "integrity": "sha512-gchesWBzyvGHRO9W8tzUWFDycow5gwjvFKfyV9FF32Y7F50yZMp7mP+T2mJIWFx49zicqyC4uefHM17o6xKIVQ=="
     },
     "node_modules/ieee754": {
       "version": "1.2.1",
@@ -1776,6 +2483,14 @@
       "integrity": "sha512-6Q9ITjvWIm0Xdqv+5U12wgOKEM2KoBw4Y926m0OFkvlCxnbG94HKAsVz8w3fWcfAS5YA2fJORXX1dLrkprCCxA==",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/is-iexplorer": {
@@ -1863,10 +2578,20 @@
       "integrity": "sha512-SW13ws7BjaeJ6p7Q6CO2nchbYEc3X3J6WrmTTDto7yMPqVSZTUyY5Tjbid+Ab8gLnATtygYtiDIJGQRRn2ZOiA==",
       "dev": true
     },
+    "node_modules/lodash.camelcase": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+      "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA=="
+    },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="
+    },
+    "node_modules/long": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.2.3.tgz",
+      "integrity": "sha512-lcHwpNoggQTObv5apGNCTdJrO69eHOZMi4BNC+rTLER8iHAqGrUVeLh/irVIM7zTw2bOXA8T6uNPeujwOLg/2Q=="
     },
     "node_modules/magic-string": {
       "version": "0.30.4",
@@ -2049,6 +2774,25 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.1.0.tgz",
       "integrity": "sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ=="
+    },
+    "node_modules/node-fetch": {
+      "version": "2.6.7",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
     },
     "node_modules/normalize-svg-path": {
       "version": "0.1.0",
@@ -2292,6 +3036,29 @@
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
     },
+    "node_modules/protobufjs": {
+      "version": "7.2.5",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.2.5.tgz",
+      "integrity": "sha512-gGXRSXvxQ7UiPgfw8gevrfRWcTlSbOFg+p/N+JVJEK5VhueL2miT6qTymqAmjr1Q5WbOCyJbyrk6JfWKwlFn6A==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.4",
+        "@protobufjs/eventemitter": "^1.1.0",
+        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/inquire": "^1.1.0",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.0",
+        "@types/node": ">=13.7.0",
+        "long": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/protocol-buffers-schema": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/protocol-buffers-schema/-/protocol-buffers-schema-3.6.0.tgz",
@@ -2408,6 +3175,14 @@
         "pick-by-alias": "^1.2.0",
         "raf": "^3.4.1",
         "regl-scatter2d": "^3.2.3"
+      }
+    },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/resolve": {
@@ -2580,6 +3355,30 @@
         "parenthesis": "^3.1.5"
       }
     },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/strongly-connected-components": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/strongly-connected-components/-/strongly-connected-components-1.0.1.tgz",
@@ -2726,6 +3525,16 @@
         "topoquantize": "bin/topoquantize"
       }
     },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+    },
+    "node_modules/tslib": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+    },
     "node_modules/type": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/type/-/type-1.2.0.tgz",
@@ -2755,6 +3564,11 @@
         "bit-twiddle": "^1.0.0",
         "dup": "^1.0.0"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
     },
     "node_modules/unquote": {
       "version": "1.1.1",
@@ -2863,6 +3677,41 @@
         "get-canvas-context": "^1.0.1"
       }
     },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+    },
+    "node_modules/websocket-driver": {
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.4.tgz",
+      "integrity": "sha512-b17KeDIQVjvb0ssuSDF2cYXSg2iztliJ4B9WdsuB6J952qCPKmnVq4DyW5motImXHDC1cBT/1UezrJVsKw5zjg==",
+      "dependencies": {
+        "http-parser-js": ">=0.5.1",
+        "safe-buffer": ">=5.1.0",
+        "websocket-extensions": ">=0.1.1"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/websocket-extensions": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.4.tgz",
+      "integrity": "sha512-OqedPIGOfsDlo31UNwYbCFMSaO9m9G/0faIHj5/dZFDMFqPTcx6UwqyOy3COEaEOg/9VsGIpdqn62W5KhoKSpg==",
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
     "node_modules/word-wrap": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
@@ -2879,6 +3728,22 @@
         "object-assign": "^4.1.0"
       }
     },
+    "node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
     "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
@@ -2890,6 +3755,39 @@
       "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
       "engines": {
         "node": ">=0.4"
+      }
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yargs": {
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "engines": {
+        "node": ">=12"
       }
     }
   }

--- a/frontend-svelte/package.json
+++ b/frontend-svelte/package.json
@@ -14,6 +14,7 @@
     "vite": "^4.4.5"
   },
   "dependencies": {
+    "firebase": "^10.5.2",
     "plotly.js": "^2.27.0",
     "plotly.js-dist": "^2.27.0"
   }

--- a/frontend-svelte/src/components/graph/Graph.svelte
+++ b/frontend-svelte/src/components/graph/Graph.svelte
@@ -1,6 +1,8 @@
 <script>
   import { onMount } from 'svelte';
-  import Plotly from 'plotly.js-dist';
+  import Plotly, { getDataToPixel } from 'plotly.js-dist';
+
+  import getData from '../../getData';
 
   let container;
 
@@ -9,6 +11,8 @@
       x: [1, 2, 3, 4, 5],
       y: [1, 2, 4, 8, 16]
     }];
+
+    getData();
 
     const layout = {
       xaxis: {

--- a/frontend-svelte/src/components/graph/Graph.svelte
+++ b/frontend-svelte/src/components/graph/Graph.svelte
@@ -6,13 +6,11 @@
 
   let container;
 
-  onMount(() => {
-    const data = [{
-      x: [1, 2, 3, 4, 5],
-      y: [1, 2, 4, 8, 16]
-    }];
-
-    getData();
+  onMount(async () => {
+    const originalData = await getData();
+    const data = [
+      originalData["Arboretum"],
+    ];
 
     const layout = {
       xaxis: {

--- a/frontend-svelte/src/components/graph/Graph.svelte
+++ b/frontend-svelte/src/components/graph/Graph.svelte
@@ -9,7 +9,7 @@
   onMount(async () => {
     const originalData = await getData();
     const data = [
-      originalData["Arboretum"],
+      originalData["Kelly Lane"],
     ];
 
     const layout = {

--- a/frontend-svelte/src/components/home/Home.svelte
+++ b/frontend-svelte/src/components/home/Home.svelte
@@ -2,19 +2,19 @@
     Solar panels have saved, to date:
   <div class="row-arrange">
     <div class="statistic">
-        <p class="large">22.89K</p>
+        <p class="large">22.22K</p>
         <p class="medium">$ Saved</p>
-        <p class="small">*based on $0.1 per kWh</p>
+        <p class="small">*based on $0.10 per kWh</p>
     </div>
   
     <div class="statistic">
-      <p class="large">347.92K</p>
+      <p class="large">222.22K</p>
       <p class="medium">lb CO2 Saved</p>
       <p class="small">*based on 1.52lb CO2 per kWh</p>
     </div>
   
     <div class="statistic">
-      <p class="large">228.89K</p>
+      <p class="large">222.22K</p>
       <p class="medium">kWh Gen.</p>
     </div>
 

--- a/frontend-svelte/src/getData.ts
+++ b/frontend-svelte/src/getData.ts
@@ -5,7 +5,7 @@ import {
 } from "firebase/firestore/lite";
 
 const firebaseConfig = {
-    apiKey: import.meta.env.COUILLARD_FIREBASE_API_KEY,
+    apiKey: "AIzaSyA-YkNpPfhJg9uHoBCnPoKhhxZtGXtrDig",
     authDomain: "couillard-b61b8.firebaseapp.com",
     projectId: "couillard-b61b8",
     storageBucket: "couillard-b61b8.appspot.com",

--- a/frontend-svelte/src/getData.ts
+++ b/frontend-svelte/src/getData.ts
@@ -5,18 +5,17 @@ import {
 } from "firebase/firestore/lite";
 
 const firebaseConfig = {
-    apiKey: "AIzaSyAaZSAsa9-7O_ffxqPPVbUsMZ13eDXH7TU",
-    authDomain: "helios-9d435.firebaseapp.com",
-    projectId: "helios-9d435",
-    storageBucket: "helios-9d435.appspot.com",
-    messagingSenderId: "768984637940",
-    appId: "1:768984637940:web:90dee43f1fc4aeafbdd9a1",
-    measurementId: "G-4FBRG6M1VB"
+    apiKey: import.meta.env.COUILLARD_FIREBASE_API_KEY,
+    authDomain: "couillard-b61b8.firebaseapp.com",
+    projectId: "couillard-b61b8",
+    storageBucket: "couillard-b61b8.appspot.com",
+    messagingSenderId: "446169152794",
+    appId: "1:446169152794:web:ff8f700af19ef89ff200a3"
 };
 
 // { <panelName>: [<date-format>, <source-timezone-offset>] }
 const DATE_PATTERNS = {
-    "__default__": ["MM-DD-YYYY", 5],
+    "__default__": ["YYYY-MM-DD", 5],
 };
 
 interface PanelData {

--- a/frontend-svelte/src/getData.ts
+++ b/frontend-svelte/src/getData.ts
@@ -14,8 +14,9 @@ const firebaseConfig = {
     measurementId: "G-4FBRG6M1VB"
 };
 
+// { <panelName>: [<date-format>, <source-timezone-offset>] }
 const DATE_PATTERNS = {
-    "__default__": "MM-DD-YYYY",
+    "__default__": ["MM-DD-YYYY", 5],
 };
 
 interface PanelData {
@@ -39,7 +40,9 @@ function basename(path: string): string | undefined {
     }
 }
 
-function parseGenericDate(date: string, pattern: string): Date {
+function parseGenericDate(date: string, patterns: [string, number]): Date {
+    let [pattern, sourceTimezoneOffsetHrs ] = patterns;
+    let sourceTimezoneOffset = sourceTimezoneOffsetHrs * 60;
     let cursor = 0;
     let got = { month: '', day: '', year: '' };
     for (const tok of pattern) {
@@ -67,11 +70,14 @@ function parseGenericDate(date: string, pattern: string): Date {
         parseInt(got.year),
         parseInt(got.month) - 1, // Months start at zero for some reason
         parseInt(got.day),
+        0, // Nothing special for hours
+        (new Date()).getTimezoneOffset() - sourceTimezoneOffset, // TZ offsets in minutes
     );
 }
 
 function parseDateFromDb(date: string, panelName: string): Date {
-    return parseGenericDate(date, DATE_PATTERNS[panelName] || DATE_PATTERNS["__default__"]);
+    return parseGenericDate(
+        date, DATE_PATTERNS[panelName] || DATE_PATTERNS["__default__"]);
 }
 
 async function asyncForEach(x: { forEach: any }, fn: (_: any) => Promise<any>): Promise<any> {

--- a/frontend-svelte/src/getData.ts
+++ b/frontend-svelte/src/getData.ts
@@ -33,13 +33,12 @@ export default async function getData() {
     return [1, 2, 2, 4];
 };
 
-function basename(path: string): string {
+function basename(path: string): string | undefined {
     for (let i = path.length - 1; i >= 0; i--) {
         if (path[i] === "/") {
             return path.slice(i + 1);
         }
     }
-    return undefined as any;
 }
 
 function parseGenericDate(date: string, pattern: string): Date {
@@ -95,6 +94,10 @@ async function assemblePanelDataObjects(
         let unsortedYears = Object.create(null);
         await asyncForEach(await getDocs(outputCol), (async outputDoc => {
             let year = basename(outputDoc.ref.path); // kinda hacky but oh well
+            if (year === undefined) {
+                console.warn('basename failed, year undefined');
+                return;
+            }
             unsortedYears[year] = Object.entries(outputDoc.data()["Output"]);
         }));
         for (let k in unsortedYears) {

--- a/frontend-svelte/src/getData.ts
+++ b/frontend-svelte/src/getData.ts
@@ -1,0 +1,65 @@
+import { initializeApp } from "firebase/app";
+import type { CollectionReference } from "firebase/firestore";
+import {
+    collection, type DocumentData, type Firestore, getDocs, getFirestore
+} from "firebase/firestore/lite";
+
+const firebaseConfig = {
+    apiKey: "AIzaSyAaZSAsa9-7O_ffxqPPVbUsMZ13eDXH7TU",
+    authDomain: "helios-9d435.firebaseapp.com",
+    projectId: "helios-9d435",
+    storageBucket: "helios-9d435.appspot.com",
+    messagingSenderId: "768984637940",
+    appId: "1:768984637940:web:90dee43f1fc4aeafbdd9a1",
+    measurementId: "G-4FBRG6M1VB"
+};
+
+interface PanelData {
+    readonly name: string;
+    readonly dates: readonly Date[];
+    readonly outputs: readonly number[];
+}
+
+export default async function getData() {
+    const app = initializeApp(firebaseConfig);
+    let db = getFirestore(app);
+    let col = collection(db, "Solar Arrays");
+    let panelDataObjs = await assemblePanelDataObjects(col);
+    console.log(panelDataObjs);
+    return [1, 2, 2, 4];
+};
+
+function basename(path: string): string {
+    for (let i = path.length - 1; i >= 0; i--) {
+        if (path[i] === "/") {
+            return path.slice(i + 1);
+        }
+    }
+    return undefined as any;
+}
+
+async function assemblePanelDataObjects(
+    col: CollectionReference<DocumentData, DocumentData>
+): Promise<readonly PanelData[]> {
+    let panelDataObjs: PanelData[] = [];
+    (await getDocs(col)).forEach(async panelDoc => {
+        let panelName = panelDoc.get("name");
+        let outputCol = collection(panelDoc.ref, "Output");
+        let unsortedYears = Object.create(null);
+        (await getDocs(outputCol)).forEach(async outputDoc => {
+            let year = basename(outputDoc.ref.path); // kinda hacky but oh well
+            unsortedYears[year] = Object.entries(outputDoc.data()["Output"]);
+        });
+        for (let k in unsortedYears) {
+            unsortedYears[k].sort(
+                (a: [string, number], b: [string, number]) => Math.sign(
+                    (new Date(a[0]) as any) - (new Date(a[1]) as any)
+                )
+            );
+            for (let i of unsortedYears[k]) {
+                console.log(i);
+            }
+        }
+    });
+    return panelDataObjs;
+}

--- a/frontend-svelte/src/getData.ts
+++ b/frontend-svelte/src/getData.ts
@@ -19,12 +19,11 @@ const DATE_PATTERNS = {
 };
 
 interface PanelData {
-    readonly name: string;
-    readonly dates: readonly Date[];
-    readonly outputs: readonly number[];
+    readonly x: readonly Date[];
+    readonly y: readonly number[];
 }
 
-export default async function getData() {
+export default async function getData(): Promise<{ [key: string]: PanelData }> {
     const app = initializeApp(firebaseConfig);
     let db = getFirestore(app);
     let col = collection(db, "Solar Arrays");
@@ -85,8 +84,8 @@ async function asyncForEach(x: { forEach: any }, fn: (_: any) => Promise<any>): 
 
 async function assemblePanelDataObjects(
     col: CollectionReference<DocumentData, DocumentData>
-): Promise<readonly PanelData[]> {
-    let panelDataObjs: PanelData[] = [];
+): Promise<{ [key: string]: PanelData }> {
+    let panelDataObjs: { [key: string]: PanelData } = Object.create(null);
     await asyncForEach(await getDocs(col), (async panelDoc => {
         let panelName = panelDoc.get("name");
         let outputCol = collection(panelDoc.ref, "Output");
@@ -121,11 +120,10 @@ async function assemblePanelDataObjects(
             dates.push(...unsortedYears[i].map((x: [Date, number]) => x[0]));
             outputs.push(...unsortedYears[i].map((x: [Date, number]) => x[1]));
         }
-        panelDataObjs.push({
-            name: panelName,
-            dates: dates,
-            outputs: outputs,
-        } as const);
+        panelDataObjs[panelName] = {
+            x: dates,
+            y: outputs,
+        } as const;
     }));
     return panelDataObjs;
 }

--- a/frontend-svelte/src/getData.ts
+++ b/frontend-svelte/src/getData.ts
@@ -29,8 +29,7 @@ export default async function getData() {
     let db = getFirestore(app);
     let col = collection(db, "Solar Arrays");
     let panelDataObjs = await assemblePanelDataObjects(col);
-    console.log(panelDataObjs);
-    return [1, 2, 2, 4];
+    return panelDataObjs;
 };
 
 function basename(path: string): string | undefined {


### PR DESCRIPTION
This adds the following:
- Connects to the database
- Organizes the data in an appropriate format for graphing
- Graphs the data from one site (Kelly Lane)
- Deals with annoying timezone nonsense

This *does not* add:
- The big text saying how many kWh total or lbs co2, those are still placeholders. I changed them all to like 222.22 so its clear that they are placeholders. 
- Graphing more than one site or a combination of sites
    - I feel like the best thing to do would be to have a dropdown for "All Sites", "Total", and then every site by itself, but that's just what I think

In code:
There's now a `getData()` function in `frontend-svelte/src/`, which returns the following structure:
```
{
   <panel-name> : {
       x: [<date-object>, ...],
       y: [<value-from-db>, ...],
   },
   ...,
}
```
**This function is not memoized, so we should really only call it once.**