### PR TITLE
Backend integration Part 2 - Totals and Fix Graph

### DIFF
--- a/frontend-svelte/src/App.svelte
+++ b/frontend-svelte/src/App.svelte
@@ -3,7 +3,6 @@
   import Home from "./components/home/Home.svelte"
   import Footer from "./components/footer/Footer.svelte"
   import Graph from "./components/graph/Graph.svelte"
-
 </script>
 
 <main>

--- a/frontend-svelte/src/components/graph/Graph.svelte
+++ b/frontend-svelte/src/components/graph/Graph.svelte
@@ -7,9 +7,13 @@
   let container;
 
   async function renderPlot(dbData) {
-    const data = [
-      dbData["Kelly Lane"],
-    ];
+    const data = [];
+    for (const [panelName, xy] of Object.entries(dbData)) {
+      data.push({
+        name: `${panelName} (kWh)`,
+        ...xy,
+      });
+    }
 
     const layout = {
       xaxis: {

--- a/frontend-svelte/src/components/graph/Graph.svelte
+++ b/frontend-svelte/src/components/graph/Graph.svelte
@@ -2,14 +2,13 @@
   import { onMount } from 'svelte';
   import Plotly, { getDataToPixel } from 'plotly.js-dist';
 
-  import getData from '../../getData';
+  import { dbData as dbDataStore } from '../../stores';
 
   let container;
 
-  onMount(async () => {
-    const originalData = await getData();
+  async function renderPlot(dbData) {
     const data = [
-      originalData["Kelly Lane"],
+      dbData["Kelly Lane"],
     ];
 
     const layout = {
@@ -42,6 +41,10 @@
     };
     //@ts-ignore
     Plotly.newPlot(container, data, layout, config);
+  }
+  
+  onMount(() => {
+    dbDataStore.subscribe(renderPlot);
   });
 </script>
   

--- a/frontend-svelte/src/components/graph/Graph.svelte
+++ b/frontend-svelte/src/components/graph/Graph.svelte
@@ -48,7 +48,9 @@
   }
   
   onMount(() => {
-    dbDataStore.subscribe(renderPlot);
+    dbDataStore.subscribe(async promise => {
+      renderPlot(await promise);
+    });
   });
 </script>
   

--- a/frontend-svelte/src/components/home/Home.svelte
+++ b/frontend-svelte/src/components/home/Home.svelte
@@ -1,8 +1,13 @@
 <script>
+    import { onMount } from 'svelte';
   import { totalData } from '../../stores';
 
-  let totals;
-  totalData.subscribe(x => { totals = x; });
+  let totals = { original: 0, derived: [], };
+  onMount(() => {
+    totalData.subscribe(async promise => {
+      totals = await promise;
+    });
+  });
 
   const compactNumberFormatter = Intl.NumberFormat('en', {
     notation: 'compact',

--- a/frontend-svelte/src/components/home/Home.svelte
+++ b/frontend-svelte/src/components/home/Home.svelte
@@ -1,23 +1,31 @@
+<script>
+  import { totalData } from '../../stores';
+
+  let totals;
+  totalData.subscribe(x => { totals = x; });
+
+  const compactNumberFormatter = Intl.NumberFormat('en', {
+    notation: 'compact',
+    maximumSignificantDigits: 4,
+  });
+  const fmtNum = x => compactNumberFormatter.format(x);
+</script>
+
 <div class="stats-row">
     Solar panels have saved, to date:
   <div class="row-arrange">
-    <div class="statistic">
-        <p class="large">22.22K</p>
-        <p class="medium">$ Saved</p>
-        <p class="small">*based on $0.10 per kWh</p>
-    </div>
-  
-    <div class="statistic">
-      <p class="large">222.22K</p>
-      <p class="medium">lb CO2 Saved</p>
-      <p class="small">*based on 1.52lb CO2 per kWh</p>
-    </div>
-  
-    <div class="statistic">
-      <p class="large">222.22K</p>
-      <p class="medium">kWh Gen.</p>
-    </div>
-
+    {#each totals.derived as [conv, unit, showDesc]}
+      <div class="statistic">
+          <p class="large">{(unit[0] === "$" ? "$" : "")}{fmtNum(conv * totals.original)}</p>
+          <p class="medium">{unit[0] === "$" ? unit.slice(1) : unit}</p>
+          {#if showDesc}
+            <p class="small">
+              *Based on {(unit[0] === "$" ? "$" : "")}{conv}
+              {unit[0] === "$" ? unit.slice(1) : unit} per kWh
+            </p>
+          {/if}
+      </div>
+    {/each}
   </div>
 </div>
 
@@ -58,6 +66,10 @@
 }
 
 .medium {
-  font-size: 1.5rem;
+  font-size: 2rem;
+}
+
+.small {
+  font-size: 1rem;
 }
 </style>

--- a/frontend-svelte/src/getData.ts
+++ b/frontend-svelte/src/getData.ts
@@ -18,7 +18,7 @@ const DATE_PATTERNS = {
     "__default__": ["YYYY-MM-DD", 5],
 };
 
-interface PanelData {
+export interface PanelData {
     readonly x: readonly Date[];
     readonly y: readonly number[];
 }

--- a/frontend-svelte/src/stores.ts
+++ b/frontend-svelte/src/stores.ts
@@ -1,5 +1,29 @@
-import { readable } from 'svelte/store';
+import { readable, derived } from 'svelte/store';
 
 import getData from './getData';
+import { type PanelData } from './getData';
 
 export const dbData = readable(await getData());
+
+const LBS_CO2_PER_KWH = 1.52;
+const DOLLARS_SAVED_PER_KWH = 0.10;
+
+function calcTotal(data: { [key: string]: PanelData }) {
+    let total = 0;
+    for (const [_panelName, xy] of Object.entries(data)) {
+        for (const output of xy.y) {
+            total += output;
+        }
+    }
+    return {
+        original: total,
+        derived: [
+            // conversion factor, unit, show description
+            [0.10, "$Saved",       true],
+            [1.52, "lbs CO2 Saved", true],
+            [1,    "kWh Generated", false],
+        ],
+    };
+}
+
+export const totalData = derived(dbData, calcTotal);

--- a/frontend-svelte/src/stores.ts
+++ b/frontend-svelte/src/stores.ts
@@ -3,7 +3,7 @@ import { readable, derived } from 'svelte/store';
 import getData from './getData';
 import { type PanelData } from './getData';
 
-export const dbData = readable(await getData());
+export const dbData = readable(getData());
 
 const LBS_CO2_PER_KWH = 1.52;
 const DOLLARS_SAVED_PER_KWH = 0.10;
@@ -33,4 +33,4 @@ function calcTotal(data: { [key: string]: PanelData }) {
     };
 }
 
-export const totalData = derived(dbData, calcTotal);
+export const totalData = derived(dbData, promise => promise.then(calcTotal));

--- a/frontend-svelte/src/stores.ts
+++ b/frontend-svelte/src/stores.ts
@@ -8,9 +8,16 @@ export const dbData = readable(await getData());
 const LBS_CO2_PER_KWH = 1.52;
 const DOLLARS_SAVED_PER_KWH = 0.10;
 
+const TOTALS_PANEL_WHITELIST = ["Kelly Lane"];
+
 function calcTotal(data: { [key: string]: PanelData }) {
     let total = 0;
-    for (const [_panelName, xy] of Object.entries(data)) {
+    for (const [panelName, xy] of Object.entries(data)) {
+        if (TOTALS_PANEL_WHITELIST !== null) {
+            if (!TOTALS_PANEL_WHITELIST.includes(panelName)) {
+                continue;
+            }
+        }
         for (const output of xy.y) {
             total += output;
         }

--- a/frontend-svelte/src/stores.ts
+++ b/frontend-svelte/src/stores.ts
@@ -1,0 +1,5 @@
+import { readable } from 'svelte/store';
+
+import getData from './getData';
+
+export const dbData = readable(await getData());


### PR DESCRIPTION
- Graph now displays data for all panels
- Totals work and are formatted properly
- You can specify a variable `TOTALS_PANEL_WHITELIST` if you want to only total from some panels (we do for now since the data is just copied). Set to null to have no whitelist. 